### PR TITLE
Add CI step for helm chart publishing

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -46,6 +46,59 @@ jobs:
       - if: ${{ needs.integration-test-reusable.result }} == 'success'
         run: echo "integration tests pass"
 
+  publish-chart:
+    runs-on: ubuntu-latest
+    needs: ["integration-test-reusable", "release-please"]
+    if: ${{ needs.release-please.outputs.release_created }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: '3.13.0'
+      
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Extract version from tag
+        id: extract_version
+        run: |
+          # Extract version from tag (e.g., image@v1.0.0 -> 1.0.0)
+          TAG="${{ needs.release-please.outputs.tag_name }}"
+          VERSION=${TAG#image@v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION"
+      
+      - name: Update Chart version
+        run: |
+          VERSION="${{ steps.extract_version.outputs.version }}"
+          sed -i "s/version: .*/version: $VERSION/" chart/Chart.yaml
+          sed -i "s/appVersion: .*/appVersion: \"$VERSION\"/" chart/Chart.yaml
+          echo "Updated Chart.yaml with version: $VERSION"
+      
+      - name: Package and publish Helm chart
+        run: |
+          VERSION="${{ steps.extract_version.outputs.version }}"
+          CHART_NAME="test-actions"
+          REGISTRY="ghcr.io/${{ github.repository_owner }}"
+          
+          # Package the chart
+          helm package chart/ --version $VERSION
+          
+          # Push to OCI registry
+          helm push ${CHART_NAME}-${VERSION}.tgz oci://${REGISTRY}
+          
+          echo "Successfully published chart ${CHART_NAME}:${VERSION} to ${REGISTRY}"
+
   separate-job:
     runs-on: ubuntu-latest
     needs: ["integration-test-reusable", "release-please"]

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -58,7 +58,13 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git fetch origin
           git switch -c image-tag-sha-${{ github.sha }}
+          
+          # Update the structured image.tag field in values.yaml
+          sed -i 's/tag: "sha-[^"]*"/tag: "sha-${{ github.sha }}"/' values.yaml
+          
+          # Also append the legacy format for backward compatibility
           echo "image: sha-${{ github.sha }}" >> values.yaml
+          
           git add values.yaml
           git commit -m "deps: update image tag to sha-${{ github.sha }}"
           git push origin image-tag-sha-${{ github.sha }}

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: test-actions
+description: A Helm chart for the test-actions application
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/chart/code
+++ b/chart/code
@@ -1,3 +1,0 @@
-bar
-bar
-baz

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "test-actions.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "test-actions.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "test-actions.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "test-actions.labels" -}}
+helm.sh/chart: {{ include "test-actions.chart" . }}
+{{ include "test-actions.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "test-actions.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "test-actions.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "test-actions.fullname" . }}
+  labels:
+    {{- include "test-actions.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "test-actions.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "test-actions.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "test-actions.fullname" . }}
+  labels:
+    {{- include "test-actions.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "test-actions.selectorLabels" . | nindent 4 }}

--- a/values.yaml
+++ b/values.yaml
@@ -1,3 +1,52 @@
+# Default values for test-actions.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/jneuff/test-actions
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "sha-9c7d5f8f159778131f849c17027c1d88a817290d"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+podAnnotations: {}
+
+service:
+  type: ClusterIP
+  port: 80
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Legacy image references (kept for backward compatibility)
+# These will be migrated to the new image.tag format
 image: sha-f05dc9563ba789b18058bd69ace65404edb17613
 image: sha-f788a9121a8ea96eacde716e6118936e299ba7a5
 image: sha-2577eaf3685706cea71c50e259db99f8bfbf2e5f


### PR DESCRIPTION
Add CI step to publish the Helm chart to GitHub Container Registry and establish a proper chart structure.

This PR introduces a complete Helm chart structure under `chart/`, configures `values.yaml`, and adds a new `publish-chart` job to the `chart.yml` workflow. This job automatically packages and pushes the chart to `ghcr.io` upon a new release. Additionally, the `container.yaml` workflow is updated to correctly manage image tags within the new `values.yaml` format.